### PR TITLE
Edit build.sh with proper path to djangoappengine.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -13,7 +13,7 @@ unzip -q build/djangotoolbox-0.9.2.zip -d build
 cp -r build/django-autoload/autoload ./autoload
 cp -r build/django-dbindexer/dbindexer ./dbindexer
 cp -r build/django-nonrel/django ./django
-cp -r build/djangoappengine ./djangoappengine
+cp -r build/djangoappengine/djangoappengine ./djangoappengine
 cp -r build/djangotoolbox/djangotoolbox ./djangotoolbox
 
 rm -r ./djangoappengine/djangoappengine.egg-info


### PR DESCRIPTION
This was causing an import error on manage.py.

``` python
vagrant@vagrant-ubuntu:~/petitions$ python manage.py runserver
Traceback (most recent call last):
  File "manage.py", line 3, in <module>
    import settings # Assumed to be in the same directory.
  File "/home/vagrant/petitions/settings.py", line 4, in <module>
    from djangoappengine.settings_base import *
ImportError: No module named djangoappengine.settings_base
```
