### PR TITLE
Updated urls.py: replaced stuff that is deprecated since Django 1.5

### DIFF
--- a/urls.py
+++ b/urls.py
@@ -1,9 +1,9 @@
-from django.conf.urls.defaults import *
+from django.conf.urls import patterns, url
+from django.views.generic.base import TemplateView
 
 handler500 = 'djangotoolbox.errorviews.server_error'
 
 urlpatterns = patterns('',
     ('^_ah/warmup$', 'djangoappengine.views.warmup'),
-    ('^$', 'django.views.generic.simple.direct_to_template',
-     {'template': 'home.html'}),
+    url(r'^$', TemplateView.as_view(template_name='home.html'))
 )


### PR DESCRIPTION
direct_to_template and django.conf.urls.defaults are deprecated so I replaced them with TemplateView and django.conf.urls

So now testapp starts without error message "Could not import django.views.generic.simple.direct_to_template…"
