### PR TITLE
Testapp 1.5 beta

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,6 @@ dbindexer
 autoload
 mediagenerator
 filetransfers
+mapreduce
 
 build

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,6 @@
 .DS_Store
 *.pyc
 .gaedata
-index.yaml
-app.yaml
 
 django
 djangotoolbox

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ filetransfers
 mapreduce
 
 build
+app.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 .DS_Store
 *.pyc
 .gaedata
+index.yaml
+app.yaml
 
 django
 djangotoolbox
@@ -13,4 +15,3 @@ filetransfers
 mapreduce
 
 build
-app.yaml

--- a/app.yaml
+++ b/app.yaml
@@ -26,5 +26,9 @@ handlers:
   static_dir: django/contrib/admin/media
   expiration: '0'
 
+- url: /static/admin
+  static_dir: django/contrib/admin/static/admin
+  expiration: '0'
+
 - url: /.*
   script: djangoappengine.main.application

--- a/app.yaml
+++ b/app.yaml
@@ -1,4 +1,4 @@
-application: ctst
+application: jitsin0
 version: 1
 runtime: python27
 api_version: 1

--- a/build.sh
+++ b/build.sh
@@ -1,19 +1,29 @@
 #!/bin/sh
 
-mkdir build
+DOWNLOAD_DIR=./src
 
-pip install --download='./build' --no-install -r requirements.txt
+# test for git and hg commands
+for cmd in git hg; do
+    command -v ${cmd} >/dev/null || { echo "sh: command not found: ${cmd}"; exit 1; }
+done
 
-unzip -q build/django-autoload-0.01.zip -d build
-unzip -q build/django-dbindexer-0.3.zip -d build
-unzip -q build/django-nonrel-1.4.5.zip -d build
-unzip -q build/djangoappengine-1.0.zip -d build
-unzip -q build/djangotoolbox-0.9.2.zip -d build
+# download all packages to ./src (default)
+pip install --no-install -r requirements.txt
 
-cp -r build/django-autoload/autoload ./autoload
-cp -r build/django-dbindexer/dbindexer ./dbindexer
-cp -r build/django-nonrel/django ./django
-cp -r build/djangoappengine/djangoappengine ./djangoappengine
-cp -r build/djangotoolbox/djangotoolbox ./djangotoolbox
+cp -r ${DOWNLOAD_DIR}/django-autoload/autoload ./autoload
+cp -r ${DOWNLOAD_DIR}/django-dbindexer/dbindexer ./dbindexer
+cp -r ${DOWNLOAD_DIR}/django-nonrel/django ./django
+cp -r ${DOWNLOAD_DIR}/djangoappengine/djangoappengine ./djangoappengine
+cp -r ${DOWNLOAD_DIR}/djangotoolbox/djangotoolbox ./djangotoolbox
 
-rm -r ./djangoappengine/djangoappengine.egg-info
+[ -f ${DOWNLOAD_DIR}/pip-delete-this-directory.txt ] && rm -rf ${DOWNLOAD_DIR}
+
+echo "Now run:
+./manage.py runserver
+
+To launch this app. If you want access to django /admin, run also:
+./manage.py createsuperuser
+
+And then login in <your_app_ip>/admin, probably http://127.0.0.1:8000/admin"
+
+

--- a/build.sh
+++ b/build.sh
@@ -7,7 +7,6 @@ for cmd in git hg; do
     command -v ${cmd} >/dev/null || { echo "sh: command not found: ${cmd}"; exit 1; }
 done
 
-<<<<<<< HEAD
 # download all packages to ./src (default)
 pip install --no-install -r requirements.txt
 
@@ -27,8 +26,6 @@ To launch this app. If you want access to django /admin, run also:
 
 And then login in <your_app_ip>/admin, probably http://127.0.0.1:8000/admin"
 
-
-=======
 unzip -q build/django-autoload-0.01.zip -d build
 unzip -q build/django-dbindexer-0.3.zip -d build
 unzip -q build/django-nonrel-1.5.zip -d build
@@ -40,4 +37,3 @@ cp -r build/django-dbindexer/dbindexer ./dbindexer
 cp -r build/django-nonrel/django ./django
 cp -r build/djangoappengine/djangoappengine ./djangoappengine
 cp -r build/djangotoolbox/djangotoolbox ./djangotoolbox
->>>>>>> django-testapp/testapp-1.5-beta

--- a/index.yaml
+++ b/index.yaml
@@ -26,3 +26,9 @@ indexes:
 # manually, move them above the marker line.  The index.yaml file is
 # automatically uploaded to the admin console when you next deploy
 # your application using appcfg.py.
+
+- kind: auth_user
+  properties:
+  - name: username
+  - name: __key__
+    direction: desc

--- a/settings.py
+++ b/settings.py
@@ -13,7 +13,7 @@ AUTOLOAD_SITECONF = 'indexes'
 SECRET_KEY = '=r-$b*8hglm+858&9t043hlm6-&6-3d3vfc4((7yd0dbrakhvi'
 
 INSTALLED_APPS = (
-#    'django.contrib.admin',
+    'django.contrib.admin',
     'django.contrib.contenttypes',
     'django.contrib.auth',
     'django.contrib.sessions',

--- a/settings.py
+++ b/settings.py
@@ -44,7 +44,8 @@ TEMPLATE_CONTEXT_PROCESSORS = (
 # corresponding output. Helps a lot with print-debugging.
 TEST_RUNNER = 'djangotoolbox.test.CapturingTestSuiteRunner'
 
-ADMIN_MEDIA_PREFIX = '/media/admin/'
+STATIC_URL = '/static/'
+
 TEMPLATE_DIRS = (os.path.join(os.path.dirname(__file__), 'templates'),)
 
 ROOT_URLCONF = 'urls'

--- a/settings.py
+++ b/settings.py
@@ -8,7 +8,8 @@ import os
 # Activate django-dbindexer for the default database
 DATABASES['default'] = {'ENGINE': 'dbindexer', 'TARGET': DATABASES['default']}
 AUTOLOAD_SITECONF = 'indexes'
-ALLOWED_HOSTS = ('.allaboutpython0.appspot.com',)
+
+ALLOWED_HOSTS = ('.jitsin0.appspot.com',)
 
 SECRET_KEY = '=r-$b*8hglm+858&9t043hlm6-&6-3d3vfc4((7yd0dbrakhvi'
 

--- a/settings.py
+++ b/settings.py
@@ -32,6 +32,7 @@ MIDDLEWARE_CLASSES = (
     'django.middleware.common.CommonMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'django.contrib.messages.middleware.MessageMiddleware',
 )
 
 TEMPLATE_CONTEXT_PROCESSORS = (

--- a/settings.py
+++ b/settings.py
@@ -8,6 +8,7 @@ import os
 # Activate django-dbindexer for the default database
 DATABASES['default'] = {'ENGINE': 'dbindexer', 'TARGET': DATABASES['default']}
 AUTOLOAD_SITECONF = 'indexes'
+ALLOWED_HOSTS = ('.allaboutpython0.appspot.com',)
 
 SECRET_KEY = '=r-$b*8hglm+858&9t043hlm6-&6-3d3vfc4((7yd0dbrakhvi'
 

--- a/templates/home.html
+++ b/templates/home.html
@@ -2,7 +2,7 @@
 {% block title %}It works!{% endblock %}
 
 {% block content %}
-<h1>It works!</h1>
+<h1>It works! for {{name}}</h1>
 <p>
 Your Django-nonrel installation is working fine. Now go and build something useful with it. :)
 </p>

--- a/urls.py
+++ b/urls.py
@@ -1,9 +1,17 @@
 from django.conf.urls.defaults import *
+from django.contrib import admin
+import dbindexer
 
 handler500 = 'djangotoolbox.errorviews.server_error'
 
+# django admin
+admin.autodiscover()
+
+# search for dbindexes.py in all INSTALLED_APPS and load them
+dbindexer.autodiscover()
+
 urlpatterns = patterns('',
     ('^_ah/warmup$', 'djangoappengine.views.warmup'),
-    ('^$', 'django.views.generic.simple.direct_to_template',
-     {'template': 'home.html'}),
+    ('^$', 'django.views.generic.simple.direct_to_template', {'template': 'home.html'}),
+    ('^admin/', include(admin.site.urls)),
 )

--- a/urls.py
+++ b/urls.py
@@ -1,6 +1,7 @@
 from django.conf.urls.defaults import *
 from django.contrib import admin
 import dbindexer
+from django.views.generic import TemplateView
 
 handler500 = 'djangotoolbox.errorviews.server_error'
 
@@ -12,6 +13,6 @@ dbindexer.autodiscover()
 
 urlpatterns = patterns('',
     ('^_ah/warmup$', 'djangoappengine.views.warmup'),
-    ('^$', 'django.views.generic.simple.direct_to_template', {'template': 'home.html'}),
+    (r'^$', TemplateView.as_view(template_name='home.html'),{'name':'home'}),
     ('^admin/', include(admin.site.urls)),
 )


### PR DESCRIPTION
direct_to_template has been deprecated. In django 1.5 using a Class based view in urls.py
